### PR TITLE
Prevent page from scrolling while zooming

### DIFF
--- a/src/interactions.js
+++ b/src/interactions.js
@@ -69,6 +69,9 @@ module.exports = function(component, renderer, container) {
     if(component.props.scrollZoom) {
 
 	container.addEventListener("wheel", (e) => {
+
+		// prevents the page from scrolling when using scroll wheel inside speck component
+		e.preventDefault();
 	    
 	    var wd = 0;
             if (e.deltaY < 0) {


### PR DESCRIPTION
Note: This changes the behavior of the component in a way which fixes something which I consider undesirable (page scrolling while zooming in and out of the molecule). Likely will need a closer look to make sure this is a "fix" we actually want put in.